### PR TITLE
Update example to neon 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "neon"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d33fe11bcc59e19cadfabd6a90ac07038eddc357f6effa25a731dd3ae7f40d6"
+checksum = "5e85820b585bf3360bf158ac87a75764c48e361c91bbeb69873e6613cc78c023"
 dependencies = [
  "cslice",
  "neon-build",
@@ -152,15 +152,15 @@ dependencies = [
 
 [[package]]
 name = "neon-build"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fe902d44ec11ccd34980b5de63b96a79ce96e231de976338166c34c43bd70b"
+checksum = "ad9febc63f515156d4311a0c43899d3ace46352ecdd591c21b98ca3974f2a0d0"
 
 [[package]]
 name = "neon-macros"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec537080e06fef83443c16fcc354a2168888770705b8cd5bc54a31e9791b777f"
+checksum = "987f12c91eb6ce0b67819f7c5fb4d391de64cf411c605ed027f03507a33943b2"
 dependencies = [
  "quote",
  "syn",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "neon-runtime"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120205ff046015597a47ab4fd81aa17f9681eae6e6ee5aa49aa3c020bb83ec99"
+checksum = "02662cd2e62b131937bdef85d0918b05bc3c204daf4c64af62845403eccb60f3"
 dependencies = [
  "cfg-if",
  "libloading",

--- a/examples/async-sqlite/Cargo.toml
+++ b/examples/async-sqlite/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["cdylib"]
 rusqlite = "0.25"
 
 [dependencies.neon]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = ["napi-6", "event-queue-api", "try-catch-api"]

--- a/examples/async-sqlite/README.md
+++ b/examples/async-sqlite/README.md
@@ -37,7 +37,7 @@ Rust data cannot be directly held by JavaScript. The [`JsBox`][jsbox] provides a
 
 #### Channels and `EventQueue`
 
-The mpsc channel provides a way for the JavaScript main thread to communicate with the database thread, but it is one-way. In order to complete the callback, the database thread must be able to communicate with the JavaScript main thread. [`EventQueue`][eventqueue] provides a channel for sending these events back.
+The mpsc channel provides a way for the JavaScript main thread to communicate with the database thread, but it is one-way. In order to complete the callback, the database thread must be able to communicate with the JavaScript main thread. [`Channel`][channel] provides a channel for sending these events back.
 
 #### `Root`
 
@@ -49,7 +49,7 @@ A [`Root`][root] is a special handle to a JavaScript value that prevents the val
 
 [thread]: https://doc.rust-lang.org/std/thread/
 [mpsc]: https://doc.rust-lang.org/std/sync/mpsc/index.html
-[jsbox]: https://docs.rs/neon/0.8.1-napi/neon/types/struct.JsBox.html
-[eventqueue]: https://docs.rs/neon/0.8.1-napi/neon/event/struct.EventQueue.html
-[handle]: https://docs.rs/neon/0.8.1-napi/neon/handle/struct.Handle.html
-[root]: https://docs.rs/neon/0.8.1-napi/neon/handle/struct.Root.html
+[jsbox]: https://docs.rs/neon/0.9.1/neon/types/struct.JsBox.html
+[channel]: https://docs.rs/neon/0.9.1/neon/event/struct.Channel.html
+[handle]: https://docs.rs/neon/0.9.1/neon/handle/struct.Handle.html
+[root]: https://docs.rs/neon/0.9.1/neon/handle/struct.Root.html

--- a/examples/async-sqlite/README.md
+++ b/examples/async-sqlite/README.md
@@ -35,9 +35,9 @@ Once the database thread is spawned, the JavaScript main thread needs a way to c
 
 Rust data cannot be directly held by JavaScript. The [`JsBox`][jsbox] provides a mechanism for allowing JavaScript to hold a reference to Rust data and later access it again from Rust.
 
-#### Channels and `EventQueue`
+#### Rust and Neon Channels
 
-The mpsc channel provides a way for the JavaScript main thread to communicate with the database thread, but it is one-way. In order to complete the callback, the database thread must be able to communicate with the JavaScript main thread. [`Channel`][channel] provides a channel for sending these events back.
+The mpsc channel provides a way for the JavaScript main thread to communicate with the database thread, but it is one-way. In order to complete the callback, the database thread must be able to communicate with the JavaScript main thread. [`neon::event::Channel`][channel] provides a channel for sending these events back.
 
 #### `Root`
 
@@ -49,7 +49,7 @@ A [`Root`][root] is a special handle to a JavaScript value that prevents the val
 
 [thread]: https://doc.rust-lang.org/std/thread/
 [mpsc]: https://doc.rust-lang.org/std/sync/mpsc/index.html
-[jsbox]: https://docs.rs/neon/0.9.1/neon/types/struct.JsBox.html
-[channel]: https://docs.rs/neon/0.9.1/neon/event/struct.Channel.html
-[handle]: https://docs.rs/neon/0.9.1/neon/handle/struct.Handle.html
-[root]: https://docs.rs/neon/0.9.1/neon/handle/struct.Root.html
+[jsbox]: https://docs.rs/neon/latest/neon/types/struct.JsBox.html
+[channel]: https://docs.rs/neon/latest/neon/event/struct.Channel.html
+[handle]: https://docs.rs/neon/latest/neon/handle/struct.Handle.html
+[root]: https://docs.rs/neon/latest/neon/handle/struct.Root.html

--- a/examples/cpu-count/Cargo.toml
+++ b/examples/cpu-count/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["cdylib"]
 num_cpus = "1"
 
 [dependencies.neon]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = ["napi-6"]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -10,6 +10,6 @@ exclude = ["index.node"]
 crate-type = ["cdylib"]
 
 [dependencies.neon]
-version = "0.8"
+version = "0.9"
 default-features = false
 features = ["napi-6"]


### PR DESCRIPTION
EventQueue was deprecated since neon 0.9. And replace it with Channel.