### PR TITLE
tokio callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 	"examples/gzip-stream",
 	"examples/hello-world",
 	"examples/tokio-fetch",
+    "examples/tokio-callback",
 ]
 
 [profile.release]

--- a/examples/tokio-callback/Cargo.toml
+++ b/examples/tokio-callback/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tokio-callback"
+version = "0.1.0"
+description = "Neon Tokio and Rust Async callback example"
+license = "MIT"
+edition = "2018"
+exclude = ["index.node"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+neon = { version = "1", features = ["futures"] }
+once_cell = "1"
+anyhow = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+futures = "0.3"
+neon-serde2 = { git = "https://github.com/druide/neon-serde" }

--- a/examples/tokio-callback/README.md
+++ b/examples/tokio-callback/README.md
@@ -1,0 +1,41 @@
+# `tokio-callback`
+
+More complex example of spawning a Rust async task on the [tokio][tokio] thread pool and resolving a JavaScript [Promise][promise] after it completes, possibly
+returning a callback result to the Rust task. This allows for an asynchronous preparation phase (like retrieving data from a database), a JavaScript processing callback (like an external service invocation, possibly asynchronous), and, when needed, an asynchronous finalization phase (for instance, writing data back to the db).
+This example builds on `tokio-fetch` example so refer to that for a simpler scenario.
+Uses [neon-serde2][neon-serde2] for serialization and [anyhow][anyhow] for error handling.
+
+[tokio]: https://tokio.rs
+[promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[neon-serde2]: https://github.com/druide/neon-serde
+[anyhow]:[https://github.com/dtolnay/anyhow]
+
+## Methods
+
+#### `tryAsJsPromise()`
+
+Allows asynchronous execution of Rust code. This is a streamlined interface that covers the same exact scenario of `tokio-fetch` example.
+
+```javascript
+let response = await module.tryAsJsPromise(request);
+```
+
+#### `tryAsJsCallback()`
+
+Allows asynchronous execution of Rust code in preparation of a synchronous javascript callback. The result of the Rust preparation is passed as argument of the JavaScript lambda function that represents the callback
+
+```javascript
+let response = await module.tryAsJsCallback((param) => {
+    return param;
+});
+```
+
+#### `tryAsAsyncJsCallback()`
+
+Allows asynchronous execution of Rust code in preparation of an asynchronous javascript callback. The result of the Rust preparation is passed as argument of the JavaScript lambda function that represents the callback. Before passing it through as response, Rust has the opportunity to intercept the callback return value
+
+```javascript
+let response = await module.tryAsJsCallback(async (param) => {
+    return param;
+});
+```

--- a/examples/tokio-callback/package.json
+++ b/examples/tokio-callback/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tokio-callback",
+  "version": "0.1.0",
+  "description": "Neon Tokio and Rust callback Async Example",
+  "main": "index.node",
+  "scripts": {
+    "build": "cargo-cp-artifact -nc index.node -- cargo build --message-format=json-render-diagnostics",
+    "install": "npm run build",
+    "test": "cargo test"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "cargo-cp-artifact": "^0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/neon-bindings/examples.git"
+  },
+  "keywords": [
+    "Neon",
+    "Examples"
+  ],
+  "bugs": {
+    "url": "https://github.com/neon-bindings/examples/issues"
+  },
+  "homepage": "https://github.com/neon-bindings/examples#readme"
+}

--- a/examples/tokio-callback/src/functions.rs
+++ b/examples/tokio-callback/src/functions.rs
@@ -1,0 +1,143 @@
+use std::{fmt::Debug, future::Future};
+
+use once_cell::sync::OnceCell;
+use tokio::runtime::Runtime;
+
+use neon::{
+    handle::Handle,
+    prelude::Context,
+    result::{JsResult, ResultExt, NeonResult},
+    types::{JsPromise, JsValue, Value},
+};
+use anyhow;
+use serde::{de::DeserializeOwned, Serialize};
+
+// Return a global tokio runtime or create one if it doesn't exist.
+// Throws a JavaScript exception if the `Runtime` fails to create.
+fn get_runtime<'a, C: Context<'a>>(cx: &mut C) -> NeonResult<&'static Runtime> {
+    static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+    RUNTIME.get_or_try_init(|| Runtime::new().or_else(|err| cx.throw_error(err.to_string())))
+}
+
+pub fn try_as_js_promise<'a, T, F, O>(mut cx: impl Context<'a>, lambda: F) -> JsResult<'a, JsPromise>
+where
+    F: FnOnce() -> O + Send + 'static,
+    O: Future<Output = anyhow::Result<T>> + Send,
+    T: Serialize + Send + Debug + 'static,
+{
+    let rt = get_runtime(&mut cx)?;
+    let channel = cx.channel();
+
+    let (deferred, promise) = cx.promise();
+
+    rt.spawn(async move {
+        let response = lambda().await;
+
+        deferred.settle_with(&channel, move |mut cx| {
+            response
+                .and_then(|response| {
+                    neon_serde2::to_value(&mut cx, &response).map_err(|err| anyhow::anyhow!(err.to_string()))
+                })
+                .or_else(|err| cx.throw_error(format!("ET000005 Converting to value: {err}")))
+        });
+    });
+
+    Ok(promise)
+}
+
+pub fn try_as_js_callback<'a, C, F, G, S, T>(
+    cx: &mut C,
+    prepare_params: F,
+    prepare_callback: G,
+) -> JsResult<'a, JsValue>
+where
+    C: Context<'a>,
+    F: FnOnce() -> S,
+    G: FnOnce(&mut C, Handle<'a, JsValue>) -> JsResult<'a, JsValue>,
+    S: Future<Output = anyhow::Result<T>>,
+    T: Serialize + DeserializeOwned + Send + Clone + 'static,
+{
+    let rt = get_runtime(cx)?;
+    let params = rt
+        .block_on(async { prepare_params().await })
+        .or_else(|err| cx.throw_error(err.to_string()))?;
+    let value = neon_serde2::to_value(cx, &params)
+        .or_else(|err| cx.throw_error(err.to_string()))?;
+
+    let result =
+        prepare_callback(cx, value).or_else(|err| cx.throw_error(err.to_string()))?;
+
+    Ok(result)
+}
+
+pub fn try_as_async_js_callback<'a, C, F, G, H, T, S, U, V, Z>(
+    cx: &mut C,
+    prepare_params: F,
+    prepare_callback: G,
+    after_callback: H,
+) -> JsResult<'a, JsPromise>
+where
+    C: Context<'a>,
+    F: FnOnce() -> S,
+    G: FnOnce(&mut C, U) -> JsResult<'a, JsPromise>,
+    H: (FnOnce(T) -> V) + Send + 'static,
+    V: Future<Output = anyhow::Result<Z>> + Send + 'static,
+    T: Serialize + DeserializeOwned + Send + Clone + 'static,
+    S: Future<Output = anyhow::Result<U>>,
+    Z: Serialize + Send + Clone + 'static,
+{
+    let rt = get_runtime(cx)?;
+
+    let channel = cx.channel();
+    let (deferred, promise) = cx.promise();
+
+    match rt.block_on(async { prepare_params().await }) {
+        Ok(params) => {
+            let callback = prepare_callback(cx, params)?;
+
+            let callback_future = callback.to_future(cx, move |mut cx, result| {
+                let value = result.or_throw(&mut cx)?.as_value(&mut cx);
+
+                let response: T = neon_serde2::from_value(&mut cx, value).or_else(|err| cx.throw_error(err.to_string()))?;
+                Ok(response)
+            })?;
+
+            rt.spawn(async move {
+                match callback_future.await {
+                    Ok(result) => match after_callback(result.clone()).await {
+                        Ok(after_result) => {
+                            deferred.settle_with(&channel, move |mut cx| {
+                                let value = neon_serde2::to_value(&mut cx, &after_result.clone()).or_else(|err| cx.throw_error(err.to_string()))?;
+                                Ok(value)
+                            });
+                        }
+                        Err(error) => {
+                            deferred.settle_with(&channel, move |mut cx| {
+                                let error = cx
+                                    .error(error.to_string())
+                                    .or_else(|err| cx.throw_error(err.to_string()))?;
+                                Ok(error.upcast::<JsValue>())
+                            });
+                        }
+                    },
+                    Err(error) => {
+                        deferred.settle_with(&channel, move |mut cx| {
+                            let error = cx.error(error.to_string()).or_else(|err| cx.throw_error(err.to_string()))?;
+                            Ok(error.upcast::<JsValue>())
+                        });
+                    }
+                }
+            });
+        }
+        Err(error) => {
+            deferred.settle_with(&channel, move |mut cx| {
+                let error = cx
+                    .error(error.to_string())
+                    .or_else(|err| cx.throw_error(err.to_string()))?;
+                Ok(error.upcast::<JsValue>())
+            });
+        }
+    }
+    Ok(promise)
+}

--- a/examples/tokio-callback/src/lib.rs
+++ b/examples/tokio-callback/src/lib.rs
@@ -1,0 +1,86 @@
+mod functions;
+
+use functions::{try_as_async_js_callback, try_as_js_callback};
+use neon::prelude::*;
+use serde::{Serialize, Deserialize};
+
+use crate::functions::try_as_js_promise;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Request {
+    pub test: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Response {
+    pub test: String,
+}
+
+
+
+
+pub fn example_try_as_js_promise(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    let arg = cx.argument::<JsValue>(0)?;
+    let request: Request = neon_serde2::from_value(&mut cx, arg).or_else(|err| {
+        cx.throw_error(err.to_string())
+    })?;
+
+    try_as_js_promise(cx, move || async move {
+        // This may be async code
+        Ok(Response { test: request.test})
+    })
+}
+
+pub fn example_try_as_js_callback(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let arg = cx.argument::<JsString>(0)?;
+    let test = arg.value(&mut cx) ;
+    let callback_function = cx.argument::<JsFunction>(1)?;
+
+    try_as_js_callback(
+        &mut cx,
+        || async { 
+            // This may be async code
+            Ok(Request { test })
+        },
+        |cx, request| {
+            let this = cx.this_value();
+            callback_function.call_with(cx).this(this).arg(request).apply(cx)
+        },
+    )
+}
+
+pub fn example_try_as_async_js_callback(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    let arg = cx.argument::<JsString>(0)?;
+    let test = arg.value(&mut cx) ;
+    let callback_function = cx.argument::<JsFunction>(1)?;
+
+
+    try_as_async_js_callback(
+        &mut cx,
+        || async {
+             // This may be async code
+             Ok(Request { test })
+        },
+        |cx, request| {
+            let this = cx.this_value();
+            let request = neon_serde2::to_value(cx, &request)
+                .or_else(|err| cx.throw_error(err.to_string()))?;
+            callback_function.call_with(cx).this(this).arg(request).apply(cx)
+        },
+        move |response: Response| async move {
+            Ok(response)
+        },
+    )
+}
+
+
+
+
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    cx.export_function("tryAsJsPromise", example_try_as_js_promise)?;
+    cx.export_function("tryAsJsCallback", example_try_as_js_callback)?;
+    cx.export_function("tryAsAsyncJsCallback", example_try_as_async_js_callback)?;
+
+    Ok(())
+}

--- a/examples/tokio-callback/test/test.js
+++ b/examples/tokio-callback/test/test.js
@@ -1,0 +1,17 @@
+import { module } from "module";
+
+async function main() {    
+
+    let response = await module.tryAsJsPromise({ test: "Hello World!"});
+    console.log("1", response);
+
+    console.log("2", await module.tryAsJsCallback("Hello World!", (param) => {
+        return param;
+    }));
+
+    console.log("3", await module.tryAsJsCallback("Hello World!", async (param) => {
+        return param;
+    }));
+}
+
+main();


### PR DESCRIPTION
These are wrappers for recurring scenarios, like the tokio-fetch but generalized.
When writing code that goes back and forth from JS to Rust, I used those three functions a lot:

* `try_as_js_promise`
* `try_as_js_callback`
* `try_as_async_js_callback`

They may need to be fine tuned, but still they offer a reusable approach and I thought it would be useful to somebody if I contribute them.

I leave this PR as Draft because I was not able to run the JavaScript `examples/tokio-callback/test/test.js`, so maybe someone can help me out with that